### PR TITLE
Fix links in Download scripts

### DIFF
--- a/Verbundkarte/Wikipedia/download.bat
+++ b/Verbundkarte/Wikipedia/download.bat
@@ -1,1 +1,1 @@
-wget --no-check-certificate -O Verbundkarte_Wikipedia.png "https://upload.wikimedia.org/wikipedia/commons/f/f3/Karte_der_Verkehrsverb%%C3%%BCnde_und_Tarifverb%%C3%%BCnde_in_Deutschland.png" 
+wget --no-check-certificate -O Verbundkarte_Wikipedia.png "https://upload.wikimedia.org/wikipedia/commons/f/f3/Karte_der_Verkehrsverb%C3%BCnde_und_Tarifverb%C3%BCnde_in_Deutschland.png"

--- a/Verwaltungsgrenzen/download.bat
+++ b/Verwaltungsgrenzen/download.bat
@@ -1,3 +1,3 @@
-wget http://sg.geodatenzentrum.de/web_download/vg/vg1000_0101/gk3/shape/vg1000_0101.gk3.shape.ebenen.zip
-unzip -jo vg1000_0101.gk3.shape.ebenen.zip vg1000_0101.gk3.shape.ebenen/vg1000_ebenen/*
-del vg1000_0101.gk3.shape.ebenen.zip
+wget https://daten.gdz.bkg.bund.de/produkte/vg/vg1000_ebenen_0101/aktuell/vg1000_01-01.gk3.shape.ebenen.zip
+unzip -jo vg1000_01-01.gk3.shape.ebenen.zip vg1000_01-01.gk3.shape.ebenen/vg1000_ebenen/*
+del vg1000_01-01.gk3.shape.ebenen.zip


### PR DESCRIPTION
As I tried the different download scripts to retrieve the image files, I was able to fix two of the broken ones, by replacing the links.